### PR TITLE
Make geojson optional, use geo-types for geometry representation.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,13 @@ keywords = ["contour", "polygon", "isoring", "marching-squares", "geojson"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-geojson = ">=0.16, <=0.24"
+geojson = { version = ">=0.16, <=0.24", optional = true }
+geo-types= { version = "0.7.0" }
 lazy_static = "1.0"
 serde_json = "^1.0"
 rustc-hash = "1.0"
 slab = "0.4"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/src/area.rs
+++ b/src/area.rs
@@ -3,10 +3,10 @@ use crate::contour::Pt;
 pub fn area(ring: &[Pt]) -> f64 {
     let mut i = 0;
     let n = ring.len() - 1;
-    let mut area = ring[n - 1][1] * ring[0][0] - ring[n - 1][0] * ring[0][1];
+    let mut area = ring[n - 1].y * ring[0].x - ring[n - 1].x * ring[0].y;
     while i < n {
         i += 1;
-        area += ring[i - 1][1] * ring[i][0] - ring[i - 1][0] * ring[i][1];
+        area += ring[i - 1].y * ring[i].x - ring[i - 1].x * ring[i].y;
     }
     area
 }
@@ -25,19 +25,19 @@ pub fn contains(ring: &[Pt], hole: &[Pt]) -> i32 {
     0
 }
 
-fn ring_contains(ring: &[Pt], point: &[f64]) -> i32 {
-    let x = point[0];
-    let y = point[1];
+fn ring_contains(ring: &[Pt], point: &Pt) -> i32 {
+    let x = point.x;
+    let y = point.y;
     let n = ring.len();
     let mut contains = -1;
     let mut j = n - 1;
     for i in 0..n {
         let pi = &ring[i];
-        let xi = pi[0];
-        let yi = pi[1];
+        let xi = pi.x;
+        let yi = pi.y;
         let pj = &ring[j];
-        let xj = pj[0];
-        let yj = pj[1];
+        let xj = pj.x;
+        let yj = pj.y;
         if segment_contains(pi, pj, point) {
             return 0;
         }
@@ -49,20 +49,20 @@ fn ring_contains(ring: &[Pt], point: &[f64]) -> i32 {
     contains
 }
 
-fn segment_contains(a: &[f64], b: &[f64], c: &[f64]) -> bool {
+fn segment_contains(a: &Pt, b: &Pt, c: &Pt) -> bool {
     if collinear(a, b, c) {
-        if (a[0] - b[0]).abs() < std::f64::EPSILON {
-            within(a[1], c[1], b[1])
+        if (a.x - b.x).abs() < std::f64::EPSILON {
+            within(a.y, c.y, b.y)
         } else {
-            within(a[0], c[0], b[0])
+            within(a.x, c.x, b.x)
         }
     } else {
         false
     }
 }
 
-fn collinear(a: &[f64], b: &[f64], c: &[f64]) -> bool {
-    ((b[0] - a[0]) * (c[1] - a[1]) - (c[0] - a[0]) * (b[1] - a[1])).abs() < std::f64::EPSILON
+fn collinear(a: &Pt, b: &Pt, c: &Pt) -> bool {
+    ((b.x - a.x) * (c.y - a.y) - (c.x - a.x) * (b.y - a.y)).abs() < std::f64::EPSILON
 }
 
 fn within(p: f64, q: f64, r: f64) -> bool {


### PR DESCRIPTION
Fixes #5 

Note this is a breaking change.

Rather than author up geometry types from scratch, I opted to use the existing geo-types for Coordinate/Polygon/MultiPolygon. If you'd prefer we could implement them directly in this crate to get rid of the dependency, but geo-types:
- is pretty stable, so this should avoid some downstream upgrade churn.
- is a smaller dependency than geojson.
- allows for interop with an ecosystem of other tools
- is a more efficient way to represent geometry. For example here are the benchmarks:

before:
```
test bench_build_geojson_contour                                       
        ... bench:       3,337 ns/iter (+/- 182)

test bench_build_geojson_contour_no_smoothing                          
        ... bench:       3,252 ns/iter (+/- 328)

test bench_build_geojson_contours_multiple_thresholds                  
        ... bench:      16,838 ns/iter (+/- 1,371)

test
bench_build_geojson_contours_multiple_thresholds_and_x_y_steps_and_origins
... bench:      16,934 ns/iter (+/- 1,325)

test bench_build_isoring                                               
        ... bench:       2,890 ns/iter (+/- 135)

test bench_build_isoring_values2                                       
        ... bench:       5,103 ns/iter (+/- 395)
```

after:
```
test bench_build_geojson_contour                                       
        ... bench:       1,917 ns/iter (+/- 29)

test bench_build_geojson_contour_no_smoothing                          
        ... bench:       1,833 ns/iter (+/- 83)

test bench_build_geojson_contours_multiple_thresholds                  
        ... bench:       9,414 ns/iter (+/- 206)

test
bench_build_geojson_contours_multiple_thresholds_and_x_y_steps_and_origins
... bench:       9,490 ns/iter (+/- 539)

test bench_build_isoring                                               
        ... bench:       1,639 ns/iter (+/- 72)

test bench_build_isoring_values2                                       
        ... bench:       2,893 ns/iter (+/- 102)
```