### PR TITLE
Minor: "cargo doc" - Fixed lint issues with ContourBuilder.

### DIFF
--- a/src/band.rs
+++ b/src/band.rs
@@ -1,7 +1,7 @@
 use crate::Float;
 use geo_types::MultiPolygon;
 
-/// An isoband has the geometry and min / max values of a contour ring, built by [`ContourBuilder`].
+/// An isoband has the geometry and min / max values of a contour ring, built by [ContourBuilder](`crate::contourbuilder::ContourBuilder`).
 #[derive(Debug, Clone)]
 pub struct Band {
     pub(crate) geometry: MultiPolygon<Float>,

--- a/src/contour.rs
+++ b/src/contour.rs
@@ -1,7 +1,7 @@
 use crate::Float;
 use geo_types::MultiPolygon;
 
-/// A contour has the geometry and threshold of a contour ring, built by [`ContourBuilder`].
+/// A contour has the geometry and threshold of a contour ring, built by [ContourBuilder](`crate::contourbuilder::ContourBuilder`).
 #[derive(Debug, Clone)]
 pub struct Contour {
     pub(crate) geometry: MultiPolygon<Float>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //! [marching squares](https://en.wikipedia.org/wiki/Marching_squares)
 //! to a rectangular array of numeric values.
 //!
-//! Use the [`ContourBuilder`]) to compute for a given set of values and thresholds:
+//! Use the [`ContourBuilder`] to compute for a given set of values and thresholds:
 //! - isolines, as a Vec of [`Line`],
 //! - contour polygons, as a Vec of [`Contour`],
 //! - isobands, as a Vec of [`Band`].

--- a/src/line.rs
+++ b/src/line.rs
@@ -1,7 +1,7 @@
 use crate::Float;
 use geo_types::MultiLineString;
 
-/// A line has the geometry and threshold of a contour ring, built by [`ContourBuilder`].
+/// A line has the geometry and threshold of a contour ring, built by [ContourBuilder](`crate::contourbuilder::ContourBuilder`).
 #[derive(Debug, Clone)]
 pub struct Line {
     pub(crate) geometry: MultiLineString<Float>,


### PR DESCRIPTION
I love this crate.... it is really useful.

I was reading the docs and notice a tiny blemish 

running

```
cargo doc
```

Showed that the flaw was repeated 3 times, thankfully the fix is just a minor nudge.

In temrs of "self" review .. I can state that I have visually checked the doc after the change
and the fix works.


``` 
warning: unresolved link to `ContourBuilder`
 --> src/line.rs:4:73
  |
4 | /// A line has the geometry and threshold of a contour ring, built by [`ContourBuilder`].
  |                                                                         ^^^^^^^^^^^^^^ no item named `ContourBuilder` in scope
  |
  = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: `contour` (lib doc) generated 3 warnings
```